### PR TITLE
update build dependency package name

### DIFF
--- a/pybind11.spec
+++ b/pybind11.spec
@@ -15,7 +15,7 @@ Source0: https://github.com/pybind/pybind11/archive/v%{version}/%{name}-%{versio
 BuildRequires: python-devel
 BuildRequires: python-setuptools
 
-BuildRequires: eigen3-devel
+BuildRequires: eigen-devel
 BuildRequires: cmake
 BuildRequires: ninja
 

--- a/pybind11.spec
+++ b/pybind11.spec
@@ -2,7 +2,7 @@
 
 Name:    pybind11
 Version:	2.13.6
-Release:	1
+Release:	2
 Summary: Seamless operability between C++11 and Python
 License: BSD
 URL:	 https://github.com/pybind/pybind11


### PR DESCRIPTION
`eigen3-devel` is marked as obsoleted package name in the eigen spec file, now named `eigen-devel`. 